### PR TITLE
avoid HTTP request loop, which will hang single-threaded development …

### DIFF
--- a/controllers/general/general_controller.php
+++ b/controllers/general/general_controller.php
@@ -56,7 +56,7 @@
       * @author: Rodrigo de Oliveira
       */
      protected function get_menu_style_json($menu_id) {
-         return get_template_directory_uri() . "/extras/cssmenumaker/menus/" . $menu_id  ."/menu.json";
+         return "../../extras/cssmenumaker/menus/" . $menu_id  ."/menu.json";
      }
 
      /**


### PR DESCRIPTION
During development, it's convenient to run a server with "php -S" instead of having Apache or php-fpm. But this makes the server single-threaded. If a file_get_contents do an HTTP request to the same server, then it will wait forever because the server is busy with current request and can't receive another connection.

Since the file is local, this makes more sense. Is there any particular reason for an HTTP request there?