### PR TITLE
Adiciona docker-compose para ambiente de desenvolvimento

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,30 @@
-version: '2'
+version: '3'
+
 services:
   database:
     image: mysql
-    container_name: some-mysql
-    environment:
-      - MYSQL_ROOT_PASSWORD=my-secret-pw
-  web:
-    container_name: tainacan
-    image: tainacan:1
-    ports:
-     - "8080:80"
     volumes:
-     - /home/leo/devel/docker:/var/www/html/wp-content/themes/tainacan
-    links:
-     - database
+      - db_data:/var/lib/mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+
+  wordpress:
+    depends_on:
+      - database
+    image: wordpress:latest
+    ports:
+      - "8000:80"
+    restart: always
+    environment:
+      WORDPRESS_DB_HOST: database:3306
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+    volumes:
+      - .:/var/www/html/wp-content/themes/tainacan
+
+volumes:
+  db_data:


### PR DESCRIPTION
Adiciona configurações no docker-compose para subir um ambiente de desenvolvimento rapidamente.
Com essas configurações qualquer pessoa que tenha docker e docker-compose instalado pode facilmente subir um ambiente de desenvolvimento.

Como algumas configurações essenciais estão expostas(como senha de banco de dados), seriam necessárias algumas otimizações para poder também subir um ambiente de produção pelo docker-compose, fora algumas possíveis configurações necessárias descritas no manual do Tainacan.