### PR TITLE
Adiciona docker-compose para ambiente do tainacan

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,8 @@ services:
     volumes:
       - db_data:/var/lib/mysql
     restart: always
-    environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: wordpress
-      MYSQL_USER: wordpress
-      MYSQL_PASSWORD: wordpress
+    env_file:
+      - docker-database.env
 
   wordpress:
     depends_on:
@@ -19,10 +16,8 @@ services:
     ports:
       - "8000:80"
     restart: always
-    environment:
-      WORDPRESS_DB_HOST: database:3306
-      WORDPRESS_DB_USER: wordpress
-      WORDPRESS_DB_PASSWORD: wordpress
+    env_file:
+      - docker-wordpress.env
     volumes:
       - .:/var/www/html/wp-content/themes/tainacan
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,30 @@
-version: '2'
+version: '3'
+
 services:
   database:
     image: mysql
-    container_name: some-mysql
-    environment:
-      - MYSQL_ROOT_PASSWORD=my-secret-pw
-  web:
-    container_name: tainacan
-    image: tainacan:1
-    ports:
-     - "8080:80"
     volumes:
-     - /home/leo/devel/docker:/var/www/html/wp-content/themes/tainacan
-    links:
-     - database
+      - db_data:/var/lib/mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+
+  wordpress:
+    depends_on:
+      - database
+    image: wordpress:latest
+    ports:
+      - "8000:80"
+    restart: always
+    environment:
+      WORDPRESS_DB_HOST: database:3306
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+    volumes:
+      - .:/var/www/html/wp-content/themes/tainacan
+
+volumes:
+  db_data:

--- a/docker-database.env
+++ b/docker-database.env
@@ -1,0 +1,5 @@
+# Para producao alterar: MYSQL_ROOT_PASSWORD, MYSQL_PASSWORD
+MYSQL_ROOT_PASSWORD=root
+MYSQL_DATABASE=wordpress
+MYSQL_USER=wordpress
+MYSQL_PASSWORD=wordpress

--- a/docker-wordpress.env
+++ b/docker-wordpress.env
@@ -1,0 +1,4 @@
+# Para producao alterar: WORDPRESS_DB_PASSWORD
+WORDPRESS_DB_HOST=database:3306
+WORDPRESS_DB_USER=wordpress
+WORDPRESS_DB_PASSWORD=wordpress


### PR DESCRIPTION
Ola, sou da equipe do LAPPIS(laboratório avançado de produção, pesquisa e inovação em software) da UNB/FGA e estou em um projeto no qual estamos levantando possíveis melhorias em projetos do minc.
No caso do tainacan acreditamos que um docker-compose para levantar o ambiente seria uma boa contribuição para o projeto neste momento.

Eu e o time do LAPPIS estamos abertos a possíveis interações futuras
***
Este PR adiciona configurações no docker-compose para subir um ambiente de rapidamente.
Com essas configurações qualquer pessoa que tenha docker e docker-compose instalado pode facilmente subir um ambiente do tainacan.

Para produção basta alterar as senhas nos arquivos de env ou sobrecrevelas no docker-compose.yml