### PR TITLE
Redirecionamento para o repositório de desenvolvimento ativo do Tainacan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,24 @@
 [![Build Status](https://travis-ci.org/medialab-ufg/tainacan.svg?branch=dev)](https://travis-ci.org/medialab-ufg/tainacan)
-# Tainacan
 
-## Brief description
+### ⚠️ Warning ⚠️ 
 
-Tainacan it is a platform that permeates the National Policy Project Digital Archives,
-this tool has been developed in partnership with the Federal University of Goiás, 
+This repository doesn't host the most recent version of Tainacan, nor is the repository in which the active development of this tool takes place. To access the source code of the most recent version of Tainacan, access [tainacan/tainacan](https://github.com/tainacan/tainacan).
+
+### What is Tainacan?
+
+Tainacan is a software solution for building, managing and publishing digital repositories of any kind on WordPress. Manage and publish you digital collections as easily as publishing a post to your blog, while having all the tools of a professional repository platform. Tainacan is composed of a WordPress plugin and an optional companion WordPress theme especially designed to produce beautiful digital exhibits.
+
+The project has been developed in partnership with the Federal University of Goiás, 
 the Ministry of Culture and the Brazilian Institute of Museums.
 
-Tainacan consists of four modules that can help manage repositories, ontologies, documents and museums.
+***
 
-[Tainacan's Handbook](./Manual%20do%20Tainacan%201.1%20-%20novo.pdf "Tainacan's Handbook")
+### ⚠️ Atenção ⚠️ 
+
+Este repositório não hospeda a versão mais recente do Tainacan, e não é o repositório em que o desenvolvimento ativo desta ferramenta ocorre. Para acessar o código-fonte da versão mais recente do Tainacan, acesse [tainacan/tainacan](https://github.com/tainacan/tainacan).
+
+### O que é o Tainacan?
+
+Tainacan é uma solução de software para construir, gerenciar e publicar acervos digitais de qualquer tipo no WordPress. Gerencie e publique as suas coleções digitais tão facilmente quanto publicar uma postagem em seu blog, ao mesmo tempo tendo acesso a todas as ferramentas de uma plataforma profissional para repositórios. Tainacan é composto de um plugin para WordPress e um tema opcional especialmente feito para produzir belas exibições digitais.
+
+O projeto tem sido desenvolvido em parceria com a Universidade Federal de Goiás, o Ministério da Cultura e o Instituto Brasileiro de Museus.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### ⚠️ Warning ⚠️ 
 
-This repository doesn't host the most recent version of Tainacan, nor is the repository in which the active development of this tool takes place. To access the source code of the most recent version of Tainacan, access [tainacan/tainacan](https://github.com/tainacan/tainacan).
+This repository doesn't offer the most recent version of Tainacan, nor is the repository in which the active development of this tool takes place. **To access the source code of the most recent version of Tainacan, access [tainacan/tainacan](https://github.com/tainacan/tainacan)**.
 
 ### What is Tainacan?
 
@@ -15,7 +15,7 @@ the Ministry of Culture and the Brazilian Institute of Museums.
 
 ### ⚠️ Atenção ⚠️ 
 
-Este repositório não hospeda a versão mais recente do Tainacan, e não é o repositório em que o desenvolvimento ativo desta ferramenta ocorre. Para acessar o código-fonte da versão mais recente do Tainacan, acesse [tainacan/tainacan](https://github.com/tainacan/tainacan).
+Este repositório não oferece a versão mais recente do Tainacan, e não é o repositório em que o desenvolvimento ativo desta ferramenta ocorre. **Para acessar o código-fonte da versão mais recente do Tainacan, acesse [tainacan/tainacan](https://github.com/tainacan/tainacan)**.
 
 ### O que é o Tainacan?
 


### PR DESCRIPTION
### Problemática 

Uma pessoa procurando pelo Tainacan no GitHub encontra o [medialab-ufg/tainacan](https://github.com/medialab-ufg/tainacan) primeiro e [tainacan/tainacan](https://github.com/tainacan/tainacan) depois. Tal classificação é ocasionada pela diferenças de estatísticas entre os dois ([medialab-ufg/tainacan](https://github.com/medialab-ufg/tainacan) possui mais estrelas e forks, mas menos pessoas observando o repositório que [tainacan/tainacan](https://github.com/tainacan/tainacan)). Enquanto [tainacan/tainacan](https://github.com/tainacan/tainacan) explicitamente diz que é um repositório voltado ao desenvolvimento, [medialab-ufg/tainacan](https://github.com/medialab-ufg/tainacan) não menciona tal dinâmica—o que pode confundir pessoas procurando pela iteração mais recente ou pelo repositório de desenvolvimento ativo.

### Resolução
O README foi modificado para abrigar mensagens em dois idiomas—português e inglês. Ele explicitamente indica que o [tainacan/tainacan](https://github.com/tainacan/tainacan) é o repositório de desenvolvimento ativo, e inclui uma breve descrição sobre o projeto.